### PR TITLE
Meson: remove positional arguments from i18n.merge_file

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -2,16 +2,14 @@ subdir('icons')
 
 po_dir = join_paths (meson.source_root (), 'po')
 
-desktop = i18n.merge_file ('desktop',
-                           input: 'com.neatdecisions.Detwinner.desktop.in',
+desktop = i18n.merge_file (input: 'com.neatdecisions.Detwinner.desktop.in',
                            output: 'com.neatdecisions.Detwinner.desktop',
                            install: true,
                            install_dir: join_paths (datadir, 'applications'),
                            po_dir: po_dir,
                            type: 'desktop')
 
-appdata = i18n.merge_file ('appdata',
-                           input: 'com.neatdecisions.Detwinner.appdata.xml.in',
+appdata = i18n.merge_file (input: 'com.neatdecisions.Detwinner.appdata.xml.in',
                            output: 'com.neatdecisions.Detwinner.appdata.xml',
                            install: true,
                            install_dir: join_paths (datadir, 'metainfo'),


### PR DESCRIPTION
i18n.merge_file has been ignoring positional arguments for a time and explicitly rejects with error since meson 0.60.0.

See mesonbuild/meson#9441.